### PR TITLE
Fix deprecation notice for Symfony 3.1

### DIFF
--- a/src/DataDog/PagerBundle/Resources/config/twig.yml
+++ b/src/DataDog/PagerBundle/Resources/config/twig.yml
@@ -3,7 +3,7 @@ parameters:
 
 services:
   datadog.pager.twig_extension:
-    class: %datadog.pager.twig_extension.class%
+    class:  '%datadog.pager.twig_extension.class%'
     arguments: ["@router"]
     tags:
       - { name: twig.extension }


### PR DESCRIPTION
Fix for:

> Not quoting the scalar "%datadog.pager.twig_extension.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.
