### PR TITLE
Raise version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
 
   "require": {
     "php": ">=5.4.0",
-    "symfony/framework-bundle": "~2.3|~3.0",
+    "symfony/framework-bundle": "2.3 - 4.0",
     "doctrine/orm": "~2.3",
-    "twig/twig": "~1.5"
+    "twig/twig": "~1.5|~2.0"
   },
 
   "require-dev": {


### PR DESCRIPTION
Needed for supporting Twig 2.0 and Symfony 4.0.

Tested with Symfony 4.0 and it seems to work very well, no errors so far.