### PR TITLE
Fix: rendering templates by using DataDogPager bundle namespace path.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,14 @@
     "ext-pdo": "*",
     "ext-pdo_sqlite": "*",
 
-    "symfony/symfony": "~3.0.0",
+    "symfony/symfony": "~3.3.0",
     "doctrine/orm": "~2.5.0",
     "doctrine/doctrine-bundle": "^1.6",
     "doctrine/doctrine-fixtures-bundle": "^2.3",
     "sensio/framework-extra-bundle": "^3.0.9",
     "fzaninotto/faker": "~1.5",
 
-    "phpunit/phpunit": "~4.7.0"
+    "phpunit/phpunit": "~6.0.0"
   },
 
   "autoload": {

--- a/src/DataDog/PagerBundle/Twig/PaginationExtension.php
+++ b/src/DataDog/PagerBundle/Twig/PaginationExtension.php
@@ -71,26 +71,26 @@ class PaginationExtension extends \Twig_Extension
         ]));
 
         return $twig->render(
-            'DataDogPagerBundle::sorters/link.html.twig',
+            '@DataDogPager/sorters/link.html.twig',
             compact('key', 'pagination', 'title', 'uri', 'direction', 'className')
         );
     }
 
     public function filterSelect(\Twig_Environment $twig, Pagination $pagination, $key, array $options)
     {
-        return $twig->render('DataDogPagerBundle::filters/select.html.twig', compact('key', 'pagination', 'options'));
+        return $twig->render('@DataDogPager/filters/select.html.twig', compact('key', 'pagination', 'options'));
     }
 
     public function filterDropdown(\Twig_Environment $twig, Pagination $pagination, $key, array $options)
     {
         $default = reset($options);
-        return $twig->render('DataDogPagerBundle::filters/dropdown.html.twig', compact('key', 'pagination', 'options', 'default'));
+        return $twig->render('@DataDogPager/filters/dropdown.html.twig', compact('key', 'pagination', 'options', 'default'));
     }
 
     public function filterSearch(\Twig_Environment $twig, Pagination $pagination, $key, $placeholder = '')
     {
         $value = isset($pagination->query()['filters'][$key]) ? $pagination->query()['filters'][$key] : '';
-        return $twig->render('DataDogPagerBundle::filters/search.html.twig', compact('key', 'pagination', 'value', 'placeholder'));
+        return $twig->render('@DataDogPager/filters/search.html.twig', compact('key', 'pagination', 'value', 'placeholder'));
     }
 
     public function filterUri(Pagination $pagination, $key, $value)
@@ -108,7 +108,7 @@ class PaginationExtension extends \Twig_Extension
 
     public function pagination(\Twig_Environment $twig, Pagination $pagination)
     {
-        return $twig->render('DataDogPagerBundle::pagination.html.twig', compact('pagination'));
+        return $twig->render('@DataDogPager/pagination.html.twig', compact('pagination'));
     }
 
     public function getName()


### PR DESCRIPTION
These syntax in Symfony 4.0 is not supported
```
{# the following template syntax is no longer recommended #}
{% extends "AppBundle::layout.html.twig" %}
{{ include('AppBundle:Foo:bar.html.twig') }}
```
I suggest using the last supported syntax:
https://symfony.com/doc/current/templating/namespaced_paths.html
