### PR TITLE
Raise symfony constraint to support 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 
   "require": {
     "php": ">=5.4.0",
-    "symfony/framework-bundle": "2.3 - 4.0",
+    "symfony/framework-bundle": "2.3 - 4.1",
     "doctrine/orm": "~2.3",
     "twig/twig": "~1.5|~2.0"
   },


### PR DESCRIPTION
Wanted to install this bundle onto a updated installation of Symfony, which is currently in v4.1. Since the current composer requires symfony <=4.0, I raised this to 4.1.